### PR TITLE
Use effect to sync player state over network

### DIFF
--- a/src/app/WebTorrents/GameServer.tsx
+++ b/src/app/WebTorrents/GameServer.tsx
@@ -194,14 +194,13 @@ export default function GameServer(props: GameServerProps): JSX.Element {
             () => {
               client.shareRoundState(round)
               const player = gameState.players[clientId]
-              const peer = clientPeerMap[clientId]
-              if (player && peer) peer.sharePlayerState(player)
+              if (player) client.sharePlayerState(player)
             },
           ],
         }
       })
     },
-    [clientPeerMap, gameState.players, round]
+    [gameState.players, round]
   )
 
   // manageSerfEvents

--- a/src/game/peers/ClientPeer.ts
+++ b/src/game/peers/ClientPeer.ts
@@ -53,14 +53,14 @@ export default class ClientPeer extends MessageEventEmitter<ClientMessage>
     }
   }
 
-  public sharePlayer = (player: Player): void => {
+  public sharePlayerState = (player: Player): void => {
     this.send({
       type: 'player',
       ...player,
     })
   }
 
-  public shareRound = (round: Round): void => {
+  public shareRoundState = (round: Round): void => {
     // FIXME Nulls get dropped when sent over to the client! e.g., 'winner' field
     this.send({
       type: 'round',

--- a/src/hooks/usePrevious.tsx
+++ b/src/hooks/usePrevious.tsx
@@ -1,0 +1,14 @@
+import {useRef, useEffect} from 'react'
+
+/**
+ * Track a variable and return its value from the previous render.
+ */
+export default function usePrevious<T>(value: T): T {
+  const ref = useRef<T>(value)
+
+  useEffect(() => {
+    ref.current = value
+  })
+
+  return ref.current
+}


### PR DESCRIPTION
Currently, we have to be disciplined and every time we update a player's state, queue up a function in `gameState.sideEffects` to share the player state with that peer. This is fairly bug prone and would be annoying to debug if we forget. Here, we use the `usePrevious` hook to manage a `useEffect` that watches for player updates and sends updates to all the appropriate players