### PR TITLE
Add useRefStableState

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1451,6 +1451,16 @@
         "sockjs-client": "^1.4.0"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-3.2.1.tgz",
+      "integrity": "sha512-1OB6Ksvlk6BCJA1xpj8/WWz0XVd1qRcgqdaFAq+xeC6l61Ucj0P6QpA5u+Db/x9gU4DCX8ziR5b66Mlfg0M2RA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.4",
+        "@types/testing-library__react-hooks": "^3.0.0"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
@@ -1708,6 +1718,16 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/testing-library__react-hooks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.2.0.tgz",
+      "integrity": "sha512-dE8iMTuR5lzB+MqnxlzORlXzXyCL0EKfzH0w/lau20OpkHD37EaWjZDz0iNG8b71iEtxT4XKGmSKAGVEqk46mw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "@types/react-test-renderer": "*"
+      }
     },
     "@types/webpack-env": {
       "version": "1.15.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2878,6 +2878,22 @@
         "dns-txt": "^2.0.2",
         "multicast-dns": "^6.0.1",
         "multicast-dns-service-types": "^1.1.0"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+          "dev": true,
+          "requires": {
+            "is-arguments": "^1.0.4",
+            "is-date-object": "^1.0.1",
+            "is-regex": "^1.0.4",
+            "object-is": "^1.0.1",
+            "object-keys": "^1.1.1",
+            "regexp.prototype.flags": "^1.2.0"
+          }
+        }
       }
     },
     "boolbase": {
@@ -3985,20 +4001,6 @@
       "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
       "requires": {
         "mimic-response": "^2.0.0"
-      }
-    },
-    "deep-equal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dev": true,
-      "requires": {
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
       }
     },
     "deep-is": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "webpack-dev-server",
     "build": "rm -rf dist && webpack --env=production",
-    "test": "tsc && eslint --ext=.tsx --ext=.ts ."
+    "test": "tsc && eslint --ext=.tsx --ext=.ts . && jest"
   },
   "repository": "",
   "bugs": "",
@@ -47,9 +47,10 @@
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.1.3",
+    "@testing-library/react-hooks": "^3.2.1",
     "@types/jest": "^24.0.17",
     "@types/react-test-renderer": "^16.9.0",
-    "@pmmmwh/react-refresh-webpack-plugin": "^0.1.3",
     "babel-loader": "^8.0.6",
     "babel-preset-kensho": "^10.0.0",
     "eslint": "^6.7.2",

--- a/src/hooks/__tests__/useReferentiallyStableState.ts
+++ b/src/hooks/__tests__/useReferentiallyStableState.ts
@@ -86,13 +86,21 @@ describe('#useReferentiallyStableState', () => {
     })
 
     it('maintains referential equality if the new updated value is equivalent to the old value.', () => {
-      const obj = {value: {a: 1}, b: 2}
+      const obj = {
+        value: {a: 1},
+        arrayValue: [1, 2, 3],
+        b: 2,
+      }
       const {result} = renderHook(useReferentiallyStableState, {initialProps: obj})
       const [value, setValue] = result.current
 
       expect(value).toBe(obj)
 
-      const newObj = {value: {a: 1}, b: 3}
+      const newObj = {
+        value: {a: 1},
+        arrayValue: [1, 2, 3],
+        b: 3,
+      }
 
       act(() => {
         setValue(newObj)
@@ -101,8 +109,8 @@ describe('#useReferentiallyStableState', () => {
 
       const [newValue] = result.current
 
-      // Though obj.b changed, obj.value should be equivalent
       expect(newValue.value).toBe(obj.value)
+      expect(newValue.arrayValue).toBe(obj.arrayValue)
       expect(newValue.b).toBe(3)
     })
 
@@ -115,7 +123,8 @@ describe('#useReferentiallyStableState', () => {
             d: 'hello',
           },
         },
-        e: true,
+        arrayValue: [{e: 1}, {f: true}, 1],
+        g: true,
       }
       const {result} = renderHook(useReferentiallyStableState, {initialProps: obj})
       const [value, setValue] = result.current
@@ -130,7 +139,8 @@ describe('#useReferentiallyStableState', () => {
             d: 'hello',
           },
         },
-        e: true,
+        arrayValue: [{e: 1}, {f: true}, 3],
+        g: true,
       }
 
       act(() => {
@@ -143,6 +153,14 @@ describe('#useReferentiallyStableState', () => {
       expect(newValue).toEqual(newObj)
       expect(newValue.value).not.toBe(obj.value)
       expect(newValue.value.c).toBe(obj.value.c)
+
+      expect(newValue.arrayValue).not.toBe(obj.arrayValue)
+      expect(newValue.arrayValue[0]).toBe(obj.arrayValue[0])
+      expect(newValue.arrayValue[1]).toBe(obj.arrayValue[1])
+      expect(newValue.arrayValue[2]).not.toBe(obj.arrayValue[2])
     })
   })
+
+  // TODO Add def
+  describe('arrays', () => {})
 })

--- a/src/hooks/__tests__/useReferentiallyStableState.ts
+++ b/src/hooks/__tests__/useReferentiallyStableState.ts
@@ -1,0 +1,104 @@
+import {renderHook, act} from '@testing-library/react-hooks'
+
+import useReferentiallyStableState from '../useReferentiallyStableState'
+
+jest.useFakeTimers()
+
+describe('#useReferentiallyStableState', () => {
+  it('initializes to the passed-in value', () => {
+    const obj = {a: 1, b: 2}
+    const {result} = renderHook(() => useReferentiallyStableState(obj))
+    const [value] = result.current
+
+    expect(value).toBe(obj)
+  })
+
+  it('correctly invalidates numbers', () => {
+    const obj = {value: 1}
+    const {result} = renderHook(v => useReferentiallyStableState(v), {
+      initialProps: obj,
+    })
+    const [value, setValue] = result.current
+
+    expect(value).toBe(obj)
+
+    const newObj = {value: 2}
+
+    act(() => {
+      setValue(newObj)
+      jest.advanceTimersByTime(100)
+    })
+
+    const [newValue] = result.current
+
+    expect(newValue).toBe(newObj)
+    expect(newValue.value).not.toBe(obj.value)
+  })
+
+  it('correctly invalidates booleans', () => {
+    const obj = {value: false}
+    const {result} = renderHook(v => useReferentiallyStableState(v), {
+      initialProps: obj,
+    })
+    const [value, setValue] = result.current
+
+    expect(value).toBe(obj)
+
+    const newObj = {value: true}
+
+    act(() => {
+      setValue(newObj)
+      jest.advanceTimersByTime(100)
+    })
+
+    const [newValue] = result.current
+
+    expect(newValue.value).toBe(newObj.value)
+    expect(newValue.value).not.toBe(obj.value)
+  })
+
+  describe('strings', () => {
+    it('maintains equality if the string is unchanged', () => {
+      const obj = {value: 'hello'}
+      const {result} = renderHook(v => useReferentiallyStableState(v), {
+        initialProps: obj,
+      })
+      const [value, setValue] = result.current
+
+      expect(value).toBe(obj)
+
+      const newObj = {value: 'hello'}
+
+      act(() => {
+        setValue(newObj)
+        jest.advanceTimersByTime(100)
+      })
+
+      const [newValue] = result.current
+
+      expect(newValue.value).toEqual(newObj.value)
+    })
+
+    it('correctly invalidates strings', () => {
+      const obj = {value: 'hello'}
+      const {result} = renderHook(v => useReferentiallyStableState(v), {
+        initialProps: obj,
+      })
+      const [value, setValue] = result.current
+
+      expect(value).toBe(obj)
+
+      const newObj = {value: 'goodbye'}
+
+      act(() => {
+        setValue(newObj)
+        jest.advanceTimersByTime(100)
+      })
+
+      const [newValue] = result.current
+
+      expect(newValue).toBe(newObj)
+      expect(newValue.value).not.toBe(obj.value)
+    })
+  })
+})

--- a/src/hooks/__tests__/useReferentiallyStableState.ts
+++ b/src/hooks/__tests__/useReferentiallyStableState.ts
@@ -161,6 +161,44 @@ describe('#useReferentiallyStableState', () => {
     })
   })
 
-  // TODO Add def
-  describe('arrays', () => {})
+  describe('arrays', () => {
+    it('maintains referential equality if the new updated value is equivalent to the old value.', () => {
+      const arr = [1, true, {a: 1}]
+      const {result} = renderHook(useReferentiallyStableState, {initialProps: arr})
+      const [value, setValue] = result.current
+
+      expect(value).toBe(arr)
+
+      const newArr = [1, true, {a: 1}]
+
+      act(() => {
+        setValue(newArr)
+        jest.advanceTimersByTime(100)
+      })
+
+      const [newValue] = result.current
+
+      // The entire object should maintain the same reference since nothing changed
+      expect(newValue).toBe(arr)
+    })
+
+    it('maintains referential equality if the new updated value is equivalent to the old value.', () => {
+      const arr = [1, true, {a: 1}]
+      const {result} = renderHook(useReferentiallyStableState, {initialProps: arr})
+      const [value, setValue] = result.current
+
+      expect(value).toBe(arr)
+
+      const newArr = [2, true, {a: 1}]
+
+      act(() => {
+        setValue(newArr)
+        jest.advanceTimersByTime(100)
+      })
+
+      const [newValue] = result.current
+      expect(newValue[0]).not.toBe(arr[0])
+      expect(newValue[2]).toBe(arr[2])
+    })
+  })
 })

--- a/src/hooks/__tests__/useReferentiallyStableState.ts
+++ b/src/hooks/__tests__/useReferentiallyStableState.ts
@@ -4,70 +4,18 @@ import useReferentiallyStableState from '../useReferentiallyStableState'
 
 jest.useFakeTimers()
 
-describe('#useReferentiallyStableState', () => {
-  it('initializes to the passed-in value', () => {
-    const obj = {a: 1, b: 2}
-    const {result} = renderHook(() => useReferentiallyStableState(obj))
-    const [value] = result.current
-
-    expect(value).toBe(obj)
-  })
-
-  it('correctly invalidates numbers', () => {
-    const obj = {value: 1}
-    const {result} = renderHook(v => useReferentiallyStableState(v), {
-      initialProps: obj,
-    })
-    const [value, setValue] = result.current
-
-    expect(value).toBe(obj)
-
-    const newObj = {value: 2}
-
-    act(() => {
-      setValue(newObj)
-      jest.advanceTimersByTime(100)
-    })
-
-    const [newValue] = result.current
-
-    expect(newValue).toBe(newObj)
-    expect(newValue.value).not.toBe(obj.value)
-  })
-
-  it('correctly invalidates booleans', () => {
-    const obj = {value: false}
-    const {result} = renderHook(v => useReferentiallyStableState(v), {
-      initialProps: obj,
-    })
-    const [value, setValue] = result.current
-
-    expect(value).toBe(obj)
-
-    const newObj = {value: true}
-
-    act(() => {
-      setValue(newObj)
-      jest.advanceTimersByTime(100)
-    })
-
-    const [newValue] = result.current
-
-    expect(newValue.value).toBe(newObj.value)
-    expect(newValue.value).not.toBe(obj.value)
-  })
-
-  describe('strings', () => {
-    it('maintains equality if the string is unchanged', () => {
-      const obj = {value: 'hello'}
-      const {result} = renderHook(v => useReferentiallyStableState(v), {
+function itHandlesPrimitiveTypes<T>(typeName: string, initialValue: T, updatedValue: T): void {
+  describe(typeName, () => {
+    it('maintains equality if the value is unchanged', () => {
+      const obj = {value: initialValue}
+      const {result} = renderHook(useReferentiallyStableState, {
         initialProps: obj,
       })
       const [value, setValue] = result.current
 
       expect(value).toBe(obj)
 
-      const newObj = {value: 'hello'}
+      const newObj = {value: initialValue}
 
       act(() => {
         setValue(newObj)
@@ -79,16 +27,16 @@ describe('#useReferentiallyStableState', () => {
       expect(newValue.value).toEqual(newObj.value)
     })
 
-    it('correctly invalidates strings', () => {
-      const obj = {value: 'hello'}
-      const {result} = renderHook(v => useReferentiallyStableState(v), {
+    it('correctly invalidates the value if changed', () => {
+      const obj = {value: initialValue}
+      const {result} = renderHook(useReferentiallyStableState, {
         initialProps: obj,
       })
       const [value, setValue] = result.current
 
       expect(value).toBe(obj)
 
-      const newObj = {value: 'goodbye'}
+      const newObj = {value: updatedValue}
 
       act(() => {
         setValue(newObj)
@@ -97,8 +45,104 @@ describe('#useReferentiallyStableState', () => {
 
       const [newValue] = result.current
 
-      expect(newValue).toBe(newObj)
+      expect(newValue).toEqual(newObj)
       expect(newValue.value).not.toBe(obj.value)
+    })
+  })
+}
+
+describe('#useReferentiallyStableState', () => {
+  it('initializes to the passed-in value', () => {
+    const obj = {a: 1, b: 2}
+    const {result} = renderHook(() => useReferentiallyStableState(obj))
+    const [value] = result.current
+
+    expect(value).toBe(obj)
+  })
+
+  itHandlesPrimitiveTypes('numbers', 1, 2)
+  itHandlesPrimitiveTypes('booleans', true, false)
+  itHandlesPrimitiveTypes('strings', 'hello', 'goodbye')
+
+  describe('objects', () => {
+    it('maintains referential equality if the new updated value is equivalent to the old value.', () => {
+      const obj = {value: {a: 1}}
+      const {result} = renderHook(useReferentiallyStableState, {initialProps: obj})
+      const [value, setValue] = result.current
+
+      expect(value).toBe(obj)
+
+      const newObj = {value: {a: 1}}
+
+      act(() => {
+        setValue(newObj)
+        jest.advanceTimersByTime(100)
+      })
+
+      const [newValue] = result.current
+
+      // The entire object should maintain the same reference since nothing changed
+      expect(newValue).toBe(obj)
+    })
+
+    it('maintains referential equality if the new updated value is equivalent to the old value.', () => {
+      const obj = {value: {a: 1}, b: 2}
+      const {result} = renderHook(useReferentiallyStableState, {initialProps: obj})
+      const [value, setValue] = result.current
+
+      expect(value).toBe(obj)
+
+      const newObj = {value: {a: 1}, b: 3}
+
+      act(() => {
+        setValue(newObj)
+        jest.advanceTimersByTime(100)
+      })
+
+      const [newValue] = result.current
+
+      // Though obj.b changed, obj.value should be equivalent
+      expect(newValue.value).toBe(obj.value)
+      expect(newValue.b).toBe(3)
+    })
+
+    it('recursively maintains referential equality if a new updated sub-value is equivalent to the old sub-value.', () => {
+      const obj = {
+        value: {
+          a: 1,
+          b: 2,
+          c: {
+            d: 'hello',
+          },
+        },
+        e: true,
+      }
+      const {result} = renderHook(useReferentiallyStableState, {initialProps: obj})
+      const [value, setValue] = result.current
+
+      expect(value).toBe(obj)
+
+      const newObj = {
+        value: {
+          a: 3,
+          b: 2,
+          c: {
+            d: 'hello',
+          },
+        },
+        e: true,
+      }
+
+      act(() => {
+        setValue(newObj)
+        jest.advanceTimersByTime(100)
+      })
+
+      const [newValue] = result.current
+
+      expect(newValue).toEqual(newObj)
+      expect(newValue.value).not.toBe(obj.value)
+      expect(newValue.value.c).toBe(obj.value.c)
     })
   })
 })

--- a/src/hooks/useReferentiallyStableState.tsx
+++ b/src/hooks/useReferentiallyStableState.tsx
@@ -1,0 +1,39 @@
+import {useState, useCallback, Dispatch, SetStateAction} from 'react'
+
+/**
+ * Manage referentially-stable state. That is, on update the new value is
+ * deep-compared with the previous value, such that a path `p` is equal
+ * (by Object.is) to the path `p` in the new state iff the values are deep-equal.
+ *
+ * @example
+ * ```
+ * const [value, setValue] = useDeepState({
+ *   a: {
+ *     b: {x: 1},
+ *     c: 3
+ *   },
+ *   d: [1, {e: 1}]
+ * })
+ * setValue(
+ *   a: {
+ *     b: {x: 1},
+ *     c: 1
+ *   },
+ *   d: [1, {e: 1}]
+ * ) // Only changes reference to `a`. `a.b` is unchanged, as well as `a.d[1]`
+ * ```
+ */
+export default function useReferentiallyStableState<T extends object>(
+  initial: T | (() => T)
+): [T, Dispatch<SetStateAction<T>>] {
+  const [value, setValue] = useState(initial)
+
+  //const deepSetValue = useCallback(
+    //(arg: T | ((prev: T) => T)) => {
+      //const newValue: T = typeof arg === 'function' ? arg(value) : arg
+    //},
+    //[value]
+  //)
+
+  return [value, setValue]
+}

--- a/src/hooks/useReferentiallyStableState.tsx
+++ b/src/hooks/useReferentiallyStableState.tsx
@@ -1,9 +1,51 @@
 import {useState, useCallback, Dispatch, SetStateAction} from 'react'
 
+function refStableReplace<T extends object>(obj: T, nextObj: T): T {
+  // Recursively replace all subkeys
+  const replaced = Object.keys(nextObj).reduce((replacedObj, key) => {
+    // @ts-ignore
+    const value = obj[key]
+    // @ts-ignore
+    const nextValue = nextObj[key]
+    const valueType = typeof nextValue
+    let replacedValue
+    switch (valueType) {
+      case 'string':
+      case 'number':
+      case 'bigint':
+      case 'boolean':
+        replacedValue = nextValue
+        break
+      case 'object':
+        if (value !== undefined && typeof value === 'object') {
+          replacedValue = refStableReplace(value, nextValue)
+        } else {
+          replacedValue = nextValue
+        }
+        break
+      default:
+        throw Error(`Invalid object provided, containing item of type '${valueType}'`)
+    }
+
+    return Object.assign(replacedObj, {[key]: replacedValue})
+  }, {} as T)
+
+  // Special case: the new replaced object is identical to the original object across all keys.
+  // Maintain ref equality by simply returning the original object
+  const allKeys = Array.from(new Set([...Object.keys(replaced), ...Object.keys(obj)]))
+  // @ts-ignore
+  if (allKeys.map(key => replaced[key] === obj[key]).every(Boolean)) {
+    return obj
+  }
+
+  return replaced
+}
+
 /**
  * Manage referentially-stable state. That is, on update the new value is
- * deep-compared with the previous value, such that a path `p` is equal
- * (by Object.is) to the path `p` in the new state iff the values are deep-equal.
+ * deep-compared with the previous value rather than replaced blindly, such
+ * that a path `p` is equal (by Object.is) to the path `p` in the new state
+ * iff the values are deep-equal.
  *
  * @example
  * ```
@@ -28,12 +70,13 @@ export default function useReferentiallyStableState<T extends object>(
 ): [T, Dispatch<SetStateAction<T>>] {
   const [value, setValue] = useState(initial)
 
-  //const deepSetValue = useCallback(
-    //(arg: T | ((prev: T) => T)) => {
-      //const newValue: T = typeof arg === 'function' ? arg(value) : arg
-    //},
-    //[value]
-  //)
+  const deepSetValue = useCallback(
+    (arg: T | ((prev: T) => T)) => {
+      const newValue: T = typeof arg === 'function' ? (arg as Function)(value) : arg
+      setValue(refStableReplace(value, newValue))
+    },
+    [value]
+  )
 
-  return [value, setValue]
+  return [value, deepSetValue]
 }

--- a/src/hooks/useReferentiallyStableState.tsx
+++ b/src/hooks/useReferentiallyStableState.tsx
@@ -21,7 +21,9 @@ function refStableReplace<T extends JsonCompatible<T>>(value: T, nextValue: T): 
       if (value !== undefined && value !== null) {
         if (Array.isArray(value) && Array.isArray(nextValue)) {
           // Both arrays, recursively replace all entries
-          const replacedArr = value.map((_, idx) => refStableReplace(value[idx], nextValue[idx]))
+          const replacedArr = nextValue.map((_, idx) =>
+            refStableReplace(value[idx], nextValue[idx])
+          )
 
           const hasSameValues = replacedArr.map((v, idx) => v === value[idx]).every(Boolean)
 
@@ -33,7 +35,12 @@ function refStableReplace<T extends JsonCompatible<T>>(value: T, nextValue: T): 
           // @ts-ignore
           return replacedArr as T
         }
-        if (!Array.isArray(value) && !Array.isArray(nextValue)) {
+        if (
+          !Array.isArray(value) &&
+          !Array.isArray(nextValue) &&
+          value != null &&
+          nextValue != null
+        ) {
           // Both objects, recursively replace all keys
           const obj = value as JsonObjectValue
           const nextObj = nextValue as JsonObjectValue

--- a/src/lib/setEqual.ts
+++ b/src/lib/setEqual.ts
@@ -1,0 +1,8 @@
+export default function setEqual<T>(fstSet: Set<T>, sndSet: Set<T>): boolean {
+  return (
+    fstSet.size === sndSet.size &&
+    Array.from(fstSet.entries())
+      .map(([entry]) => sndSet.has(entry))
+      .every(Boolean)
+  )
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,3 +7,5 @@ export type Dictionary<K extends string | number | symbol, V> = Record<K, V | un
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never
+
+export type NonNull<T> = Exclude<T, null>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,3 +9,23 @@ export type Dictionary<K extends string | number | symbol, V> = Record<K, V | un
 export type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never
 
 export type NonNull<T> = Exclude<T, null>
+
+export type JsonValue = null | boolean | number | string | JsonValue[] | {[prop: string]: JsonValue}
+
+export interface JsonObjectValue {
+  [prop: string]: JsonValue
+}
+
+/*
+ * A type that only matches against JSON-compatible values.
+ *
+ * E.g., JsonCompatible<string> and JsonCompatible<{key: number}> have members,
+ * while JsonCompatible<Date> and JsonCompatible<Function> do not.
+ */
+export type JsonCompatible<T> = {
+  [P in keyof T]: T[P] extends JsonValue
+    ? T[P]
+    : Pick<T, P> extends Required<Pick<T, P>>
+    ? never
+    : JsonCompatible<T[P]>
+}


### PR DESCRIPTION
The UI needs to react to state updates from the server, but since data is sent over the wire we can't rely on referential equality in order to detect changes (i.e., it's a new object every time). This PR adds a new hook called `useRefStableState` which maintains JSON-compatible state and, on update, maintains referential equality with the original value wherever possible. 