### PR TITLE
Persist username and game key in storage

### DIFF
--- a/src/app/Homepage/index.tsx
+++ b/src/app/Homepage/index.tsx
@@ -1,14 +1,9 @@
 import * as React from 'react'
 import {css} from '@emotion/core'
 import {Link} from 'react-router-dom'
-import createPersistedState from 'use-persisted-state'
 
-const {NODE_ENV} = process.env
-
-const useUsernameState = createPersistedState(
-  'username',
-  NODE_ENV === 'production' ? localStorage : sessionStorage
-)
+import useUsernameState from '../../hooks/game/useUsernameState'
+import useGameKeyState from '../../hooks/game/useGameKeyState'
 
 const wrapperCss = css({
   height: '100vh',
@@ -21,35 +16,45 @@ const mainCss = css({
   minHeight: 0,
 })
 
-function gameLink(username: string, host: boolean): string {
-  if (host) return `/g?u=${username}&h`
-  return `/g?u=${username}`
-}
-
 export default function Homepage(): JSX.Element {
   const [username, setUsername] = useUsernameState('')
+  const [gameKey, setGameKey] = useGameKeyState('')
 
   return (
     <div css={wrapperCss}>
       <main css={mainCss}>
         <form>
-          <input
-            type="text"
-            value={username}
-            onChange={e => setUsername(e.target.value)}
-            placeholder="Username"
-          />
+          <div>
+            <input
+              type="text"
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+              placeholder="Username"
+            />
+          </div>
+          <div>
+            <input
+              type="text"
+              value={gameKey}
+              onChange={e => setGameKey(e.target.value)}
+              placeholder="Game Code"
+            />
+          </div>
         </form>
-        <div>
-          <Link to={gameLink(username, true)}>
-            <button type="button">Host a Game</button>
-          </Link>
-        </div>
-        <div>
-          <Link to={gameLink(username, false)}>
-            <button type="button">Join a Game</button>
-          </Link>
-        </div>
+        {username.length > 0 && gameKey.length > 0 && (
+          <div>
+            <div>
+              <Link to="/g?h">
+                <button type="button">Host a Game</button>
+              </Link>
+            </div>
+            <div>
+              <Link to="/g">
+                <button type="button">Join Game</button>
+              </Link>
+            </div>
+          </div>
+        )}
       </main>
     </div>
   )

--- a/src/app/WebTorrents/Server.tsx
+++ b/src/app/WebTorrents/Server.tsx
@@ -7,6 +7,8 @@ import log from '../../lib/log'
 import hexdigest from '../../lib/hexdigest'
 import omit from '../../lib/omit'
 import useStableValue from '../../hooks/useStableValue'
+import useUsernameState from '../../hooks/game/useUsernameState'
+import useGameKeyState from '../../hooks/game/useGameKeyState'
 import useTorrent from '../../hooks/useTorrent'
 import {SwarmPeer, PeerMetadata} from '../../engine/types'
 import useSwarmCommExtension, {SwarmExtendedWire} from '../../engine/useSwarmCommExtension'
@@ -25,16 +27,6 @@ function useQueryParams(): URLSearchParams {
   const location = useLocation()
   const params = useMemo(() => new URLSearchParams(location.search), [location])
   return params
-}
-
-/**
- * Query param `u` corresponds to the username
- */
-function useUsername(): string {
-  const params = useQueryParams()
-  const username = useMemo(() => params.get('u') || new Date().getTime().toString(), [params])
-
-  return username
 }
 
 /**
@@ -63,7 +55,8 @@ function useLocalhostPeers(metadata: PeerMetadata | null): [SwarmPeer, SwarmPeer
  * u - username. defaults to current time.
  */
 export default function Server(): JSX.Element {
-  const username = useUsername()
+  const [username] = useUsernameState(() => new Date().getTime().toString())
+  const [gameKey] = useGameKeyState()
   const isLeader = useIsLeader()
 
   const [leader, setLeader] = useState<string | null>(null)
@@ -133,7 +126,7 @@ export default function Server(): JSX.Element {
     [setConns]
   )
 
-  const torrent = useTorrent(SEED)
+  const torrent = useTorrent(`${SEED}-${gameKey}`)
 
   // manageHandshake
   useEffect(() => {

--- a/src/hooks/game/useGameKeyState.tsx
+++ b/src/hooks/game/useGameKeyState.tsx
@@ -1,0 +1,5 @@
+import createPersistedState from 'use-persisted-state'
+
+const useGameKeyState = createPersistedState('game-key')
+
+export default useGameKeyState

--- a/src/hooks/game/useUsernameState.tsx
+++ b/src/hooks/game/useUsernameState.tsx
@@ -1,0 +1,10 @@
+import createPersistedState from 'use-persisted-state'
+
+const {NODE_ENV} = process.env
+
+const useUsernameState = createPersistedState(
+  'username',
+  NODE_ENV === 'production' ? localStorage : sessionStorage
+)
+
+export default useUsernameState


### PR DESCRIPTION
Adds the ability to specify a game key, so that separate games can be played and separate devs can iterate locally without colliding with others.
Also instead of grabbing username and game key from the URL, grab from local and session storage.