### PR TITLE
Use tweetnacl for hashing while developing locally

### DIFF
--- a/src/lib/hexdigest.tsx
+++ b/src/lib/hexdigest.tsx
@@ -1,9 +1,13 @@
+import * as nacl from 'tweetnacl'
+
 /**
  * Compute the SHA-256 hash of some data, returning a hex string.
  */
-export default async function hexdigest(data: ArrayBuffer): Promise<string> {
-  // NOTE: Chrome 60+ disables crypto.subtle over non-TLS connections
-  const hash = await crypto.subtle.digest('SHA-256', data)
+export default async function hexdigest(data: Uint8Array): Promise<string> {
+  const hash =
+    process.env.NODE_ENV === 'production'
+      ? await crypto.subtle.digest('SHA-256', data) // NOTE: Chrome 60+ disables crypto.subtle over non-TLS connections
+      : await new Promise<Uint8Array>(resolve => resolve(nacl.hash(data)))
   const byteArray = Array.from(new Uint8Array(hash))
 
   const hex = byteArray.map(b => b.toString(16).padStart(2, '0')).join('')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,8 +20,13 @@ module.exports = env => {
     },
     plugins: [
       new MiniCssExtractPlugin({filename: isDev ? '[name].css' : '[name].[contenthash].css'}),
-      new webpack.EnvironmentPlugin({GIT_REV: gitInfo.sha}),
-      new HTMLPlugin({title: 'WebRTC Experiments'}),
+      new webpack.EnvironmentPlugin({GIT_REV: gitInfo.sha, NODE_ENV: process.env.NODE_ENV}),
+      new HTMLPlugin({
+        title: 'WebRTC Experiments',
+        meta: {
+          viewport: 'initial-scale=1',
+        },
+      }),
       new ReactRefreshPlugin({disableRefreshCheck: true}),
     ].filter(Boolean),
     devtool: isDev ? 'cheap-module-source-map' : 'source-map',


### PR DESCRIPTION
`crypto.subtle` is disabled in insecure contexts (i.e., local dev), which makes it impossible to test the app on mobile. This PR creates a switch to use the `hash` function from `tweetnacl` when not in production.