### PR TITLE
Automatically provide new players with the correct number of cards

### DIFF
--- a/src/app/Game/PlayerHand.tsx
+++ b/src/app/Game/PlayerHand.tsx
@@ -194,6 +194,7 @@ export default function PlayerHand(props: PlayerHandProps): JSX.Element {
       <animated.div {...handDragEvents()} style={{x: dragXProps.x}} css={handCss}>
         {cards.map((card, cardIndex) => (
           <animated.div
+            key={card.id}
             style={{
               x: cardIndex * CARD_WIDTH,
               y: cardSprings[cardIndex].y,

--- a/src/game/peers/ClientPeer.ts
+++ b/src/game/peers/ClientPeer.ts
@@ -19,7 +19,7 @@ export default class ClientPeer extends MessageEventEmitter<ClientMessage>
     return this.peer.ext
   }
 
-  private destroyed: boolean = false
+  private _destroyed: boolean = false
 
   constructor(peer: SwarmPeer) {
     super()
@@ -32,9 +32,13 @@ export default class ClientPeer extends MessageEventEmitter<ClientMessage>
    * Mark peer as destroyed and clean up all listeners. Idempotent.
    */
   public destroy = (): void => {
-    this.destroyed = true
+    this._destroyed = true // eslint-disable-line no-underscore-dangle
     this.ext.removeAllListeners()
     this.removeAllListeners()
+  }
+
+  public get destroyed(): boolean {
+    return this._destroyed // eslint-disable-line no-underscore-dangle
   }
 
   public send = (message: ServerMessage): void => {


### PR DESCRIPTION
When new players are added to the server, they will automatically be sent a full hand.
Also switches away from state updates during the render phase of `GameServer` in favor of `useLayoutEffect`.