### PR TITLE
Only give confirmed new peers cards

### DIFF
--- a/src/app/Game/GameServer.tsx
+++ b/src/app/Game/GameServer.tsx
@@ -113,13 +113,14 @@ export default function GameServer(props: GameServerProps): JSX.Element {
       const addedPeers = next.filter(peer => addedIds.has(peer.metadata.id))
 
       // All new players should receive a full hand
-      addedPeers.forEach(peer =>
+      const confirmedNewPeers = addedPeers.filter(peer => !gameState.players[peer.metadata.id])
+      confirmedNewPeers.forEach(peer =>
         giveClientCard(peer)({
           number: STARTING_HAND_SIZE,
         })
       )
     },
-    [giveClientCard]
+    [gameState.players, giveClientCard]
   )
 
   const handleClientRequestCzar = useCallback(


### PR DESCRIPTION
Realized there was a little loophole: if a player drops out and reconnects, they shouldn't be given a full new hand since that would get appended to their previous hand. In this PR we first check which peers are "confirmed new" by checking that their ID doesn't exist in the game state.