### PR TITLE
Persist keypair to sessionStorage

### DIFF
--- a/src/app/Game/GameServer.tsx
+++ b/src/app/Game/GameServer.tsx
@@ -112,13 +112,18 @@ export default function GameServer(props: GameServerProps): JSX.Element {
       const addedIds = new Set([...nextIds].filter(id => !prevIds.has(id)))
       const addedPeers = next.filter(peer => addedIds.has(peer.metadata.id))
 
-      // All new players should receive a full hand
-      const confirmedNewPeers = addedPeers.filter(peer => !gameState.players[peer.metadata.id])
-      confirmedNewPeers.forEach(peer =>
-        giveClientCard(peer)({
-          number: STARTING_HAND_SIZE,
-        })
-      )
+      addedPeers.forEach(peer => {
+        const playerState = gameState.players[peer.metadata.id]
+        // All new players should receive a full hand
+        if (!playerState) {
+          giveClientCard(peer)({
+            number: STARTING_HAND_SIZE,
+          })
+        } else {
+          // A player has rejoined, notify them of their state again
+          peer.sharePlayerState(playerState)
+        }
+      })
     },
     [gameState.players, giveClientCard]
   )

--- a/src/hooks/game/useSignKeyPair.tsx
+++ b/src/hooks/game/useSignKeyPair.tsx
@@ -1,0 +1,32 @@
+import {useMemo} from 'react'
+import * as nacl from 'tweetnacl'
+import createPersistedState from 'use-persisted-state'
+
+const useKeypairState = createPersistedState('keypair', window.sessionStorage)
+
+function serializeUint8(arr: Uint8Array): number[] {
+  return arr
+    .toString()
+    .split(',')
+    .map(Number)
+}
+
+export default function useSignKeyPair(): nacl.SignKeyPair {
+  const [jsonSignKeyPair] = useKeypairState(() => {
+    const keypair = nacl.sign.keyPair()
+    return {
+      publicKey: serializeUint8(keypair.publicKey),
+      secretKey: serializeUint8(keypair.secretKey),
+    }
+  })
+
+  const signKeyPair = useMemo<nacl.SignKeyPair>(
+    () => ({
+      publicKey: Uint8Array.from(jsonSignKeyPair.publicKey),
+      secretKey: Uint8Array.from(jsonSignKeyPair.secretKey),
+    }),
+    [jsonSignKeyPair]
+  )
+
+  return signKeyPair
+}


### PR DESCRIPTION
Uses `use-persisted-state` as usual to persist the keypair to sessionStorage, and share player state when a player rejoins the game. This makes it possible to refresh and *get the same cards back*.