### PR TITLE
Fix listener memory leak

### DIFF
--- a/src/app/Game/GameClient.tsx
+++ b/src/app/Game/GameClient.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useCallback, useMemo} from 'react'
+import React, {useState, useEffect, useLayoutEffect, useCallback, useMemo} from 'react'
 
 import {SwarmPeer, PeerMetadata} from '../../engine/types'
 import {
@@ -48,12 +48,6 @@ export default function GameClient(props: GameClientProps): JSX.Element {
   const isCzar = selfMetadata.id === czar
   const isSerf = czar !== null && !isCzar
 
-  if (rawServerPeer !== prevRawServerPeer) {
-    serverPeer.destroy()
-    setServerPeer(new ServerPeer(rawServerPeer))
-    setPrevRawServerPeer(rawServerPeer)
-  }
-
   const requestCard = useCallback(() => {
     serverPeer.requestCards(1)
   }, [serverPeer])
@@ -88,7 +82,16 @@ export default function GameClient(props: GameClientProps): JSX.Element {
     [serverPeer]
   )
 
-  // manageServerPeer
+  // manageServerPeerChange
+  useLayoutEffect(() => {
+    if (rawServerPeer !== prevRawServerPeer) {
+      serverPeer.destroy()
+      setServerPeer(new ServerPeer(rawServerPeer))
+      setPrevRawServerPeer(rawServerPeer)
+    }
+  }, [prevRawServerPeer, rawServerPeer, serverPeer])
+
+  // manageServerPeerEvents
   useEffect(() => {
     serverPeer.on('player', setPlayer)
     serverPeer.on('round', updateRound)

--- a/src/game/peers/ClientPeer.ts
+++ b/src/game/peers/ClientPeer.ts
@@ -42,7 +42,7 @@ export default class ClientPeer extends MessageEventEmitter<ClientMessage>
   }
 
   public send = (message: ServerMessage): void => {
-    this.peer.ext.send({
+    this.ext.send({
       type: 'data',
       data: message,
     })

--- a/src/game/peers/ServerPeer.ts
+++ b/src/game/peers/ServerPeer.ts
@@ -26,13 +26,12 @@ export default class ServerPeer extends MessageEventEmitter<ServerMessage>
     this.peer = peer
 
     this.ext.on('receive-message', this.handleMessage)
-    this.id = Math.round(Math.random() * 100)
-    // FIXME We end up with two listeners, ext.removeAllListeners is not working as expected.
-    console.log(this.id, this.ext.listeners('receive-message'))
   }
 
   public destroy = (): void => {
     this._destroyed = true // eslint-disable-line no-underscore-dangle
+    this.ext.removeAllListeners()
+    this.removeAllListeners()
   }
 
   public get destroyed(): boolean {
@@ -47,7 +46,6 @@ export default class ServerPeer extends MessageEventEmitter<ServerMessage>
   }
 
   private handleMessage = (_: unknown, message: Message): void => {
-    console.log('HANDLING: ', this.id)
     this.assertAlive()
     if (message.type === 'data') {
       const serverMsg = message.data as ServerMessage

--- a/src/lib/TypedEventEmitter.ts
+++ b/src/lib/TypedEventEmitter.ts
@@ -48,7 +48,7 @@ export default class TypedEventEmitter<Events> extends EventEmitter {
   ): this => super.removeListener(event, listener as Listener)
 
   public removeAllListeners = <K extends keyof Base<Events>>(event?: K): this =>
-    super.removeAllListeners(event)
+    event === undefined ? super.removeAllListeners() : super.removeAllListeners(event)
 
   public listeners = <K extends keyof Base<Events>>(event: K): Function[] => super.listeners(event)
 


### PR DESCRIPTION
Nodejs's `EventEmitter#removeAllListeners` was not removing all listeners because we were passing in an argument of `undefined` rather than passing in no args.